### PR TITLE
Update Webpack get methods to include options

### DIFF
--- a/webpack.d.ts
+++ b/webpack.d.ts
@@ -36,26 +36,28 @@ export interface Webpack {
     getAllByRegex(regex: RegExp, options?: BaseSearchOptions): any[];
 
     /** Finds a single module using properties on its prototype. */
-    getByPrototypeKeys(...prototypes: string[]): any;
+    getByPrototypeKeys(...prototypes: WithOptions<string, BaseSearchOptions>): any;
 
     /** Finds all modules with a set of properties of its prototype. */
-    getAllByPrototypeKeys(...prototypes: string[]): any[];
+    getAllByPrototypeKeys(...prototypes: WithOptions<string, BaseSearchOptions>): any[];
 
     /** Finds a single module using its own properties. */
-    getByKeys(...props: string[]): any;
+    getByKeys(...props: WithOptions<string, BaseSearchOptions>): any;
 
     /** Finds all modules with a set of properties. */
-    getAllByKeys(...props: string[]): any[];
+    getAllByKeys(...props: WithOptions<string, BaseSearchOptions>): any[];
 
     /** Finds a single module using a set of strings. */
-    getByStrings(...strings: string[]): any;
+    getByStrings(...strings: WithOptions<string, BaseSearchOptions>): any;
 
     /** Finds all modules with a set of strings. */
-    getAllByStrings(...strings: string[]): any[];
+    getAllByStrings(...strings: WithOptions<string, BaseSearchOptions>): any[];
 
     /** Finds an internal Store module using the name. */
     getStore(name: string): any;
 }
+
+type WithOptions<T, B extends BaseSearchOptions> = [...T[], B] | T[]
 
 export type ModuleFilter = (
     exports: any,

--- a/webpack.d.ts
+++ b/webpack.d.ts
@@ -57,7 +57,7 @@ export interface Webpack {
     getStore(name: string): any;
 }
 
-type WithOptions<T, B extends BaseSearchOptions> = [...T[], B] | T[]
+export type WithOptions<T, B extends BaseSearchOptions> = [...T[], B] | T[]
 
 export type ModuleFilter = (
     exports: any,


### PR DESCRIPTION
Update Webpack's ``getBy`` and ``getAllBy`` methods to allow providing an options object.

- In the case of ``getAllBy-``, ``first`` is overridden to ``false``, so there's no point using ``SearchOptions`` over ``BaseSearchOptions``.
- In the case of ``getBy-``, ``first`` can be provided by the user. However, ``getAllBy-`` is an alias for providing ``first`` as ``false`` (returning any[]), and the default is ``true`` (returning any), so I don't think it's worthwhile using ``SearchOptions``'s extra type parameter here either.