### PR TITLE
Fix DialogResult

### DIFF
--- a/ui.d.ts
+++ b/ui.d.ts
@@ -88,15 +88,15 @@ export interface DialogSaveOptions extends DialogOptions {
 }
 
 export interface DialogResult {
-    cancelled: boolean;
+    canceled: boolean;
     filePath?: string;
     filePaths?: string[];
 }
 
-export interface DialogOpenResult extends Omit<DialogResult, "filePaths"> {
-    filePath: string;
+export interface DialogOpenResult extends Omit<DialogResult, "filePath"> {
+    filePaths: string[];
 }
 
-export interface DialogSaveResult extends Omit<DialogResult, "filePath"> {
-    filePaths: string[];
+export interface DialogSaveResult extends Omit<DialogResult, "filePaths"> {
+    filePath: string;
 }


### PR DESCRIPTION
The DialogOpenResult and DialogCloseResult have their properties switched. OpenResult should return multiple file paths whereas CloseResult should only have one. Additionally, there is a typo where DialogResult has a property called cancelled with two ls instead of one.