### PR TITLE
add explicit .d.ts extensions for BetterDiscord types to support Deno

### DIFF
--- a/bdapi.d.ts
+++ b/bdapi.d.ts
@@ -1,19 +1,19 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import type * as React from "react";
+import type * as ReactDOM from "react-dom";
 
-import { AddonAPI } from "./addonapi";
-import { ContextMenu } from "./contextmenu";
-import { Data, BoundData } from "./data";
-import { DOM, BoundDOM } from "./dom";
-import { Net } from "./net";
-import { Patcher, BoundPatcher } from "./patcher";
-import { ReactUtils } from "./reactutils";
-import { UI } from "./ui";
-import { Utils } from "./utils";
-import { Webpack } from "./webpack";
-import { Legacy } from "./legacy";
-import { Components } from "./components";
-import { Logger, BoundLogger } from "./logger";
+import type { AddonAPI } from "./addonapi.d.ts";
+import type { ContextMenu } from "./contextmenu.d.ts";
+import type { Data, BoundData } from "./data.d.ts";
+import type { DOM, BoundDOM } from "./dom.d.ts";
+import type { Net } from "./net.d.ts";
+import type { Patcher, BoundPatcher } from "./patcher.d.ts";
+import type { ReactUtils } from "./reactutils.d.ts";
+import type { UI } from "./ui.d.ts";
+import type { Utils } from "./utils.d.ts";
+import type { Webpack } from "./webpack.d.ts";
+import type { Legacy } from "./legacy.d.ts";
+import type { Components } from "./components.d.ts";
+import type { Logger, BoundLogger } from "./logger.d.ts";
 
 /** BetterDiscord's global plugin API. */
 export interface BdApi extends Legacy {

--- a/contextmenu.d.ts
+++ b/contextmenu.d.ts
@@ -1,4 +1,4 @@
-import { Cancel } from ".";
+import type { Cancel } from "./index.d.ts";
 
 export interface ContextMenu extends ContextMenuComponents {
     /**

--- a/dom.d.ts
+++ b/dom.d.ts
@@ -1,4 +1,4 @@
-import { Cancel } from ".";
+import type { Cancel } from "./index.d.ts";
 
 export interface DOM {
     /** Current width of the user's screen. */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,20 @@
-import { BdApi } from "./bdapi";
+import type { BdApi } from "./bdapi.d.ts";
 
-export * from "./addonapi";
-export * from "./bdapi";
-export * from "./components";
-export * from "./contextmenu";
-export * from "./data";
-export * from "./dom";
-export * from "./logger";
-export * from "./net";
-export * from "./patcher";
-export * from "./plugin";
-export * from "./reactutils";
-export * from "./ui";
-export * from "./utils";
-export * from "./webpack";
-export * from "./legacy";
+export type * from "./addonapi.d.ts";
+export type * from "./bdapi.d.ts";
+export type * from "./components.d.ts";
+export type * from "./contextmenu.d.ts";
+export type * from "./data.d.ts";
+export type * from "./dom.d.ts";
+export type * from "./logger.d.ts";
+export type * from "./net.d.ts";
+export type * from "./patcher.d.ts";
+export type * from "./plugin.d.ts";
+export type * from "./reactutils.d.ts";
+export type * from "./ui.d.ts";
+export type * from "./utils.d.ts";
+export type * from "./webpack.d.ts";
+export type * from "./legacy.d.ts";
 
 export type Cancel = () => void;
 

--- a/legacy.d.ts
+++ b/legacy.d.ts
@@ -1,8 +1,8 @@
-import { Fiber } from "react-reconciler";
+import type { Fiber } from "react-reconciler";
 
-import { Cancel } from ".";
-import { ModuleFilter } from "./webpack";
-import {
+import type { Cancel } from "./index.d.ts";
+import type { ModuleFilter } from "./webpack.d.ts";
+import type {
     CloseNotice,
     ConfirmationModalOptions,
     DialogOpenOptions,
@@ -11,7 +11,7 @@ import {
     DialogSaveResult,
     NoticeOptions,
     ToastOptions,
-} from "./ui";
+} from "./ui.d.ts";
 
 /** @deprecated */
 export interface Legacy {

--- a/patcher.d.ts
+++ b/patcher.d.ts
@@ -1,4 +1,4 @@
-import { Cancel } from "./index";
+import type { Cancel } from "./index.d.ts";
 
 type FnOrAny<F> = F extends (...args: any) => any ? F : any;
 

--- a/reactutils.d.ts
+++ b/reactutils.d.ts
@@ -1,4 +1,4 @@
-import { Fiber } from "react-reconciler";
+import type { Fiber } from "react-reconciler";
 
 export interface ReactUtils {
     get rootInstance(): any;

--- a/ui.d.ts
+++ b/ui.d.ts
@@ -1,4 +1,4 @@
-import { Setting, SettingGroupProps } from "./components";
+import type { Setting, SettingGroupProps } from "./components.d.ts";
 
 export interface UI {
     /** Shows a generic but customizable modal. */


### PR DESCRIPTION
When building a project with Deno, the lack of explicit file extensions lead to a failure to resolve the local module imports.

To remedy this, this PR makes the type definitions and extensions explicit, allowing Deno to resolve the dependency tree.