### PR TITLE
Update webpack types

### DIFF
--- a/webpack.d.ts
+++ b/webpack.d.ts
@@ -103,6 +103,8 @@ export type ExportedOnlyFilter = (exports: any) => boolean;
 export interface BaseSearchOptions {
     defaultExport?: boolean;
     searchExports?: boolean;
+    searchDefault?: boolean;
+    raw?: boolean;
     fatal?: boolean;
     firstId?: PropertyKey;
     cacheId?: string | null;

--- a/webpack.d.ts
+++ b/webpack.d.ts
@@ -62,6 +62,12 @@ export interface Webpack {
     /** Finds all modules with a set of strings. */
     getAllByStrings<T>(...strings: WithOptions<string, BaseSearchOptions>): T[];
 
+    /** Finds a single module with a set of strings in its source code. */
+    getBySource<T>(...strings: WithOptions<string, BaseSearchOptions>): T;
+
+    /** Finds all modules with a set of strings in their source code. */
+    getAllBySource<T>(...strings: WithOptions<string, BaseSearchOptions>): T;
+
     /** Finds an internal Store module using the name. */
     getStore<T>(name: string): T;
 
@@ -156,6 +162,9 @@ export interface Filters {
 
     /** Generates a filter checking for a specific internal Store name. */
     byStoreName(name: string): ModuleFilter;
+
+    /** Generates a filter checking the strings in the source of a module */
+    bySource(...strings: string[]): ModuleFilter;
 
     /** Generates a combined filter from multiple filters. */
     combine(...filters: ModuleFilter[]): ModuleFilter;

--- a/webpack.d.ts
+++ b/webpack.d.ts
@@ -26,7 +26,9 @@ export interface Webpack {
     getBulk<Q extends ModuleQuery[]>(...queries: Q): ModuleBulkResult<Q>;
 
     /** Finds multiple modules using multiple filters on an object. */
-    getBulkKeyed<T extends Record<string, ModuleQuery>>(queries: T): ModuleBulkKeyedResult<T>;
+    getBulkKeyed<T extends Record<string, ModuleQuery>>(
+        queries: T,
+    ): ModuleBulkKeyedResult<T>;
 
     /** Attempts to find a lazy loaded module, resolving when it is loaded. */
     waitForModule<T>(
@@ -132,7 +134,7 @@ export type ModuleBulkResult<Q extends ModuleQuery[]> = {
 
 export type ModuleBulkKeyedResult<T extends Record<string, ModuleQuery>> = {
     [K in keyof T]: T[K]["all"] extends true ? any[] : any;
-}
+};
 
 export interface WaitForModuleOptions extends BaseSearchOptions {
     signal?: AbortSignal;


### PR DESCRIPTION
This adds some of BetterDiscord's newer Webpack features, specifically `Webpack.getBulkKeyed`, `Webpack.getById`, `Webpack.getMangled`, `Webpack.getBySource`, `Webpack.getAllBySource`, `Filters.bySource`, and `Filters.not`. It also adds `fatal`, `cacheId`, and `firstId` to the search options, and fixes an issue with the `getBulk` type.