### PR TITLE
Fix compatibility with `"isolatedModules": true`

### DIFF
--- a/commands.d.ts
+++ b/commands.d.ts
@@ -35,17 +35,10 @@ export interface Command {
     predicate?(): boolean;
 }
 
-export enum OptionType {
-    STRING = 3,
-    INTEGER = 4,
-    BOOLEAN = 5,
-    USER = 6,
-    CHANNEL = 7,
-    ROLE = 8,
-    MENTIONABLE = 9,
-    NUMBER = 10,
-    ATTACHMENT = 11,
-}
+export type OptionType = Exclude<
+    OptionTypes,
+    OptionTypes.SUB_COMMAND | OptionTypes.SUB_COMMAND_GROUP
+>;
 
 export interface Choice {
     name: string;

--- a/commands.d.ts
+++ b/commands.d.ts
@@ -35,7 +35,7 @@ export interface Command {
     predicate?(): boolean;
 }
 
-export const enum OptionType {
+export enum OptionType {
     STRING = 3,
     INTEGER = 4,
     BOOLEAN = 5,
@@ -64,13 +64,13 @@ export interface Option {
     choices?: Choice[];
 }
 
-export const enum CommandTypes {
+export enum CommandTypes {
     CHAT_INPUT = 1,
     USER = 2,
     MESSAGE = 3,
 }
 
-export const enum InputTypes {
+export enum InputTypes {
     BUILT_IN = 0,
     TEXT = 1,
     SEARCH = 2,
@@ -78,7 +78,7 @@ export const enum InputTypes {
     PLACEHOLDER = 4,
 }
 
-export const enum OptionTypes {
+export enum OptionTypes {
     SUB_COMMAND = 1,
     SUB_COMMAND_GROUP = 2,
     STRING = 3,
@@ -92,7 +92,7 @@ export const enum OptionTypes {
     ATTACHMENT = 11,
 }
 
-export const enum MessageEmbedTypes {
+export enum MessageEmbedTypes {
     IMAGE = "image",
     VIDEO = "video",
     LINK = "link",

--- a/components/button.d.ts
+++ b/components/button.d.ts
@@ -1,13 +1,13 @@
 export type ButtonTypes = "button" | "submit" | "reset";
 
-export const enum ButtonLooks {
+export enum ButtonLooks {
     FILLED = "bd-button-filled",
     OUTLINED = "bd-button-outlined",
     LINK = "bd-button-link",
     BLANK = "bd-button-blank",
 }
 
-export const enum ButtonColors {
+export enum ButtonColors {
     BRAND = "bd-button-color-brand",
     BLURPLE = "bd-button-color-blurple",
     RED = "bd-button-color-red",
@@ -20,7 +20,7 @@ export const enum ButtonColors {
     CUSTOM = "",
 }
 
-export const enum ButtonSizes {
+export enum ButtonSizes {
     NONE = "",
     TINY = "bd-button-tiny",
     SMALL = "bd-button-small",

--- a/components/flex.d.ts
+++ b/components/flex.d.ts
@@ -1,10 +1,10 @@
-export const enum FlexDirection {
+export enum FlexDirection {
     VERTICAL = "bd-flex-vertical",
     HORIZONTAL = "bd-flex-horizontal",
     HORIZONTAL_REVERSE = "bd-flex-reverse",
 }
 
-export const enum FlexJustify {
+export enum FlexJustify {
     START = "bd-flex-justify-start",
     END = "bd-flex-justify-end",
     CENTER = "bd-flex-justify-center",
@@ -12,7 +12,7 @@ export const enum FlexJustify {
     AROUND = "bd-flex-justify-around",
 }
 
-export const enum FlexAlign {
+export enum FlexAlign {
     START = "bd-flex-align-start",
     END = "bd-flex-align-end",
     CENTER = "bd-flex-align-center",
@@ -20,7 +20,7 @@ export const enum FlexAlign {
     BASELINE = "bd-flex-align-baseline",
 }
 
-export const enum FlexWrap {
+export enum FlexWrap {
     NO_WRAP = "bd-flex-no-wrap",
     WRAP = "bd-flex-wrap",
     WRAP_REVERSE = "bd-flex-wrap-reverse",

--- a/components/spinner.d.ts
+++ b/components/spinner.d.ts
@@ -1,4 +1,4 @@
-export const enum SpinnerType {
+export enum SpinnerType {
     WANDERING_CUBES = "wandering-cubes",
     CHASING_DOTS = "chasing-dots",
     PULSING_ELLIPSIS = "pulsing-ellipsis",

--- a/components/text.d.ts
+++ b/components/text.d.ts
@@ -1,4 +1,4 @@
-export const enum TextColors {
+export enum TextColors {
     STANDARD = "bd-text-normal",
     MUTED = "bd-text-muted",
     ERROR = "bd-text-error",
@@ -13,7 +13,7 @@ export const enum TextColors {
     CUSTOM = "",
 }
 
-export const enum TextSizes {
+export enum TextSizes {
     SIZE_10 = "bd-text-10",
     SIZE_12 = "bd-text-12",
     SIZE_14 = "bd-text-14",


### PR DESCRIPTION
I'm [building a BetterDiscord plugin](https://github.com/jh0ker/better-discord-transcribe-voice-notes) and while upgrading today, I experienced some build errors related to `const enum` definitions.

```
> yarn build
yarn run v1.22.22
$ tsc && vite build
src/components/transcribe-button.tsx:82:18 - error TS2748: Cannot access ambient const enums when 'isolatedModules' is enabled.

82           color={BdApi.Components.Button.Colors.CUSTOM}
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/components/transcribe-button.tsx:83:17 - error TS2748: Cannot access ambient const enums when 'isolatedModules' is enabled.

83           size={BdApi.Components.Button.Sizes.SMALL}
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 2 errors in the same file, starting at: src/components/transcribe-button.tsx:82

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

It looks like the [usage of `const enum` is incompatible with `"isolatedModules": true`](https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls), but this is [needed for vite](https://vite.dev/guide/features#typescript-compiler-options) and even [bundling with esbuild in general](https://esbuild.github.io/content-types/#isolated-modules).

As far as my understanding goes, there is no downside in this case to remove the `const` part of the declarations, since it's just type declarations anyways.